### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/aiw-devops/45f98843-6554-416d-996d-3fa16d6edd40/91c4730c-84c3-4b24-ae36-d5e44b029201/_apis/work/boardbadge/eb7e1d23-d2b1-40d9-bdc8-d1b4dbe55236)](https://dev.azure.com/aiw-devops/45f98843-6554-416d-996d-3fa16d6edd40/_boards/board/t/91c4730c-84c3-4b24-ae36-d5e44b029201/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#622](https://dev.azure.com/aiw-devops/45f98843-6554-416d-996d-3fa16d6edd40/_workitems/edit/622). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.